### PR TITLE
Initialize llm client with credentials

### DIFF
--- a/homebox/__init__.py
+++ b/homebox/__init__.py
@@ -1,6 +1,6 @@
 """Public API for the Homebox demo helper library."""
 from .client import DEFAULT_HEADERS, DEMO_BASE_URL, HomeboxDemoClient
-from .llm import detect_items_with_openai, encode_image_to_data_uri
+from .llm import HomeboxLLMClient, detect_items_with_openai, encode_image_to_data_uri
 from .models import DetectedItem
 
 __all__ = [
@@ -8,6 +8,7 @@ __all__ = [
     "DEFAULT_HEADERS",
     "DetectedItem",
     "HomeboxDemoClient",
+    "HomeboxLLMClient",
     "detect_items_with_openai",
     "encode_image_to_data_uri",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "homebox"
-version = "0.1.1"
+version = "0.1.2"
 description = "Demo API utilities and OpenAI vision helpers for Homebox"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from homebox.llm import detect_items_with_openai, encode_image_to_data_uri
+from homebox.llm import HomeboxLLMClient, detect_items_with_openai, encode_image_to_data_uri
 from homebox.models import DetectedItem
 
 IMAGE_PATH = Path(__file__).resolve().parent / "assets" / "test_detection.jpg"
@@ -48,6 +48,47 @@ def test_detected_item_from_raw_items_handles_invalid_entries() -> None:
     assert detected[1].label_ids == ["123"]
 
 
+def test_llm_client_requires_api_key_for_detection() -> None:
+    """Ensure the client raises an error when API key is missing."""
+    # Clear any environment variable that might be set
+    original_key = os.environ.pop("OPENAI_API_KEY", None)
+    try:
+        client = HomeboxLLMClient()
+        with pytest.raises(ValueError, match="OpenAI API key must be provided"):
+            _ = client.api_key
+    finally:
+        if original_key:
+            os.environ["OPENAI_API_KEY"] = original_key
+
+
+def test_llm_client_accepts_api_key_from_env() -> None:
+    """Ensure the client can read the API key from the environment."""
+    original_key = os.environ.get("OPENAI_API_KEY")
+    os.environ["OPENAI_API_KEY"] = "test-key-from-env"
+    try:
+        client = HomeboxLLMClient()
+        assert client.api_key == "test-key-from-env"
+    finally:
+        if original_key:
+            os.environ["OPENAI_API_KEY"] = original_key
+        else:
+            os.environ.pop("OPENAI_API_KEY", None)
+
+
+def test_llm_client_prefers_explicit_api_key() -> None:
+    """Ensure the explicit API key takes precedence over env var."""
+    original_key = os.environ.get("OPENAI_API_KEY")
+    os.environ["OPENAI_API_KEY"] = "env-key"
+    try:
+        client = HomeboxLLMClient(api_key="explicit-key")
+        assert client.api_key == "explicit-key"
+    finally:
+        if original_key:
+            os.environ["OPENAI_API_KEY"] = original_key
+        else:
+            os.environ.pop("OPENAI_API_KEY", None)
+
+
 @pytest.mark.integration
 def test_detect_items_with_openai_live() -> None:
     api_key = os.environ.get("OPENAI_API_KEY")
@@ -56,6 +97,7 @@ def test_detect_items_with_openai_live() -> None:
 
     model = os.getenv("OPENAI_MODEL", "gpt-5-mini")
 
+    # Test using the legacy function
     detected_items = detect_items_with_openai(image_path=IMAGE_PATH, api_key=api_key, model=model)
 
     print("Live OpenAI detection response:")
@@ -77,3 +119,43 @@ def test_detect_items_with_openai_live() -> None:
     for item in detected_items:
         assert item.name, "Detected item names should not be empty."
         assert item.quantity >= 1, "Detected quantities should be at least 1."
+
+
+@pytest.mark.integration
+def test_llm_client_detect_items_live() -> None:
+    """Test the class-based LLM client for item detection."""
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        pytest.skip("OPENAI_API_KEY must be set to hit the OpenAI API for live tests.")
+
+    model = os.getenv("OPENAI_MODEL", "gpt-5-mini")
+
+    # Test using the new class-based client
+    client = HomeboxLLMClient(api_key=api_key, model=model)
+    detected_items = client.detect_items(IMAGE_PATH)
+
+    print("Live OpenAI detection response (class-based client):")
+    for idx, item in enumerate(detected_items, start=1):
+        summary = f"  {idx}. {item.name} (qty: {item.quantity})"
+        details = item.description or "no description"
+        print(f"{summary} - {details}")
+
+    assert detected_items, "Expected at least one detected item from OpenAI."
+    for item in detected_items:
+        assert item.name, "Detected item names should not be empty."
+        assert item.quantity >= 1, "Detected quantities should be at least 1."
+
+
+@pytest.mark.integration
+def test_llm_client_fetch_labels_live() -> None:
+    """Test the class-based LLM client for fetching labels."""
+    # This test doesn't require an OpenAI API key
+    client = HomeboxLLMClient(api_key="unused-for-labels")
+    labels = client.fetch_labels()
+
+    print(f"Fetched {len(labels)} labels from Homebox demo API")
+    for label in labels[:5]:  # Print first 5
+        print(f"  - {label['name']} (id: {label['id']})")
+
+    # The demo environment should have some labels
+    assert isinstance(labels, list)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -119,7 +119,7 @@ wheels = [
 
 [[package]]
 name = "homebox"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "openai" },


### PR DESCRIPTION
Refactor the LLM client to a class-based approach, allowing credentials to be set during initialization.

---
<a href="https://cursor.com/background-agent?bcId=bc-bde4bf71-57f4-4f4c-968a-3da94c645496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bde4bf71-57f4-4f4c-968a-3da94c645496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `HomeboxLLMClient` with API key management, labels fetching, and image detection; deprecates legacy functions and bumps version to 0.1.2.
> 
> - **LLM Library**:
>   - **New**: `HomeboxLLMClient` encapsulates API key resolution (env/explicit), lazy `OpenAI` client, `fetch_labels`, and `detect_items` with JSON response formatting.
>   - **Deprecated**: `detect_items_with_openai` and `fetch_demo_labels` now wrap the new client.
>   - Public API updated to export `HomeboxLLMClient`; improved label URL handling via `rstrip('/')`.
> - **Tests**:
>   - Add unit tests for API key requirements/precedence and data-URI encoding.
>   - Add integration tests for class-based detection and label fetching; update imports.
> - **Version**:
>   - Bump `homebox` to `0.1.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8720bef58be11a5e3d04350fc0cfc7616d92c98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->