### PR TITLE
Optimize log file reading

### DIFF
--- a/server/api/logs.py
+++ b/server/api/logs.py
@@ -1,6 +1,7 @@
 """Logs API routes for debugging and reference."""
 
 import os
+from collections import deque
 from glob import glob
 
 from fastapi import APIRouter, HTTPException, Query
@@ -53,13 +54,14 @@ async def get_logs(
 
     try:
         with open(log_file, encoding="utf-8") as f:
-            all_lines = f.readlines()
+            # Use deque to keep only the last N lines in memory
+            recent_lines: deque[str] = deque(maxlen=lines)
+            total_lines = 0
+            for line in f:
+                recent_lines.append(line)
+                total_lines += 1
 
-        total_lines = len(all_lines)
         truncated = total_lines > lines
-
-        # Get last N lines
-        recent_lines = all_lines[-lines:] if truncated else all_lines
         logs_content = "".join(recent_lines)
 
         return LogsResponse(


### PR DESCRIPTION
Optimize the logs endpoint to read only the last N lines of a log file, preventing excessive memory usage.

The previous implementation loaded the entire log file into memory using `f.readlines()` before extracting the last N lines. This PR changes it to use `collections.deque` with a `maxlen` parameter, ensuring only the last N lines are ever held in memory, which is crucial for large log files.

---
<a href="https://cursor.com/background-agent?bcId=bc-e08d42b6-bf6a-4f66-affd-cb34fcf788ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e08d42b6-bf6a-4f66-affd-cb34fcf788ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

