### PR TITLE
Fix network request cancellation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -915,7 +915,6 @@
 			"integrity": "sha512-oH8tXw7EZnie8FdOWYrF7Yn4IKrqTFHhXvl8YxXxbKwTMcD/5NNCryUSEXRk2ZR4ojnub0P8rNrsVGHXWqIDtA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
@@ -955,7 +954,6 @@
 			"integrity": "sha512-YZs/OSKOQAQCnJvM/P+F1URotNnYNeU3P2s4oIpzm1uFaqUEqRxUB0g5ejMjEb5Gjb9/PiBI5Ktrq4rUUF8UVQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
 				"debug": "^4.4.1",
@@ -1015,7 +1013,6 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1178,7 +1175,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.25",
 				"caniuse-lite": "^1.0.30001754",
@@ -1628,7 +1624,6 @@
 			"integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"jiti": "bin/jiti.js"
 			}
@@ -1842,7 +1837,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -1890,7 +1884,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -2273,7 +2266,6 @@
 			"integrity": "sha512-ngKXNhNvwPzF43QqEhDOue7TQTrG09em1sd4HBxVF0Wr2gopAmdEWan+rgbdgK4fhBtSOTJO8bYU4chUG7VXZQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2497,7 +2489,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -2550,7 +2541,6 @@
 			"integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.5.0",

--- a/frontend/src/lib/api/items.ts
+++ b/frontend/src/lib/api/items.ts
@@ -5,20 +5,29 @@
 import { request, requestFormData } from './client';
 import type { BatchCreateRequest, BatchCreateResponse } from '../types';
 
+export interface CreateOptions {
+	signal?: AbortSignal;
+}
+
+export interface UploadOptions {
+	signal?: AbortSignal;
+}
+
 export const items = {
-	create: (data: BatchCreateRequest) =>
+	create: (data: BatchCreateRequest, options: CreateOptions = {}) =>
 		request<BatchCreateResponse>('/items', {
 			method: 'POST',
 			body: JSON.stringify(data),
+			signal: options.signal,
 		}),
 
-	uploadAttachment: (itemId: string, file: File) => {
+	uploadAttachment: (itemId: string, file: File, options: UploadOptions = {}) => {
 		const formData = new FormData();
 		formData.append('file', file);
 		return requestFormData<unknown>(
 			`/items/${itemId}/attachments`,
 			formData,
-			'Failed to upload attachment'
+			{ errorMessage: 'Failed to upload attachment', signal: options.signal }
 		);
 	},
 };

--- a/frontend/src/lib/api/vision.ts
+++ b/frontend/src/lib/api/vision.ts
@@ -17,11 +17,25 @@ export interface DetectOptions {
 	extraInstructions?: string;
 	extractExtendedFields?: boolean;
 	additionalImages?: File[];
+	signal?: AbortSignal;
 }
 
 export interface BatchDetectOptions {
 	configs?: Array<{ single_item?: boolean; extra_instructions?: string }>;
 	extractExtendedFields?: boolean;
+	signal?: AbortSignal;
+}
+
+export interface AnalyzeOptions {
+	signal?: AbortSignal;
+}
+
+export interface MergeOptions {
+	signal?: AbortSignal;
+}
+
+export interface CorrectOptions {
+	signal?: AbortSignal;
 }
 
 export const vision = {
@@ -50,7 +64,7 @@ export const vision = {
 		return requestFormData<DetectionResponse>(
 			'/tools/vision/detect',
 			formData,
-			'Detection failed'
+			{ errorMessage: 'Detection failed', signal: options.signal }
 		);
 	},
 
@@ -75,7 +89,7 @@ export const vision = {
 		return requestFormData<BatchDetectionResponse>(
 			'/tools/vision/detect-batch',
 			formData,
-			'Batch detection failed'
+			{ errorMessage: 'Batch detection failed', signal: options.signal }
 		);
 	},
 
@@ -85,7 +99,8 @@ export const vision = {
 	analyze: (
 		images: File[],
 		itemName: string,
-		itemDescription?: string
+		itemDescription?: string,
+		options: AnalyzeOptions = {}
 	): Promise<AdvancedItemDetails> => {
 		const formData = new FormData();
 		for (const img of images) {
@@ -99,17 +114,18 @@ export const vision = {
 		return requestFormData<AdvancedItemDetails>(
 			'/tools/vision/analyze',
 			formData,
-			'Analysis failed'
+			{ errorMessage: 'Analysis failed', signal: options.signal }
 		);
 	},
 
 	/**
 	 * Merge multiple items into a single consolidated item using AI
 	 */
-	merge: (itemsToMerge: MergeItem[]) =>
+	merge: (itemsToMerge: MergeItem[], options: MergeOptions = {}) =>
 		request<MergedItemResponse>('/tools/vision/merge', {
 			method: 'POST',
 			body: JSON.stringify({ items: itemsToMerge }),
+			signal: options.signal,
 		}),
 
 	/**
@@ -118,7 +134,8 @@ export const vision = {
 	correct: (
 		image: File,
 		currentItem: MergeItem,
-		correctionInstructions: string
+		correctionInstructions: string,
+		options: CorrectOptions = {}
 	): Promise<CorrectionResponse> => {
 		const formData = new FormData();
 		formData.append('image', image);
@@ -128,7 +145,7 @@ export const vision = {
 		return requestFormData<CorrectionResponse>(
 			'/tools/vision/correct',
 			formData,
-			'Correction failed'
+			{ errorMessage: 'Correction failed', signal: options.signal }
 		);
 	},
 };


### PR DESCRIPTION
Enable true cancellation of network requests by passing AbortSignals to API calls.

Previously, `AbortController` instances were created, but their signals were not propagated to the underlying `fetch` calls in `client.ts`, `vision.ts`, and `items.ts`. This meant that UI-level cancellations did not stop in-flight network requests, leading to wasted bandwidth and potential for double-processing. This PR ensures that `AbortSignal` is correctly passed down, allowing actual network request termination upon cancellation.

---
<a href="https://cursor.com/background-agent?bcId=bc-669b0400-e127-4128-8851-f89d2a138011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-669b0400-e127-4128-8851-f89d2a138011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

