### PR TITLE
Consolidate submission attachment logic

### DIFF
--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -102,6 +102,9 @@ export type ScanStatus =
 	| 'submitting'  // Creating items in Homebox
 	| 'complete';   // Success
 
+/** Status of individual item submission */
+export type ItemSubmissionStatus = 'pending' | 'creating' | 'success' | 'partial_success' | 'failed';
+
 /** Progress for async operations */
 export interface Progress {
 	current: number;
@@ -127,6 +130,8 @@ export interface ScanState {
 	confirmedItems: ConfirmedItem[];
 	// Submission
 	submissionProgress: Progress | null;
+	/** Per-item submission status for UI feedback */
+	itemStatuses: Record<number, ItemSubmissionStatus>;
 	// Error handling
 	error: string | null;
 }


### PR DESCRIPTION
Consolidate duplicated item submission and attachment upload logic into `ScanWorkflow`.

The previous implementation had significant duplication in `scanWorkflow.submitAll` and `summary/+page.svelte`, including identical request payload building, attachment upload retry logic, and `dataUrlToFile` helpers. This PR centralizes all submission logic into the `ScanWorkflow` class, introduces `ItemSubmissionStatus` for per-item tracking, and refactors the summary page to be a thin view, reducing code duplication and improving maintainability.

---
<a href="https://cursor.com/background-agent?bcId=bc-f78d4374-a4f7-4fa2-bffb-2daea72300eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f78d4374-a4f7-4fa2-bffb-2daea72300eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

