### PR TITLE
Remove homebox submit overlay

### DIFF
--- a/frontend/src/routes/summary/+page.svelte
+++ b/frontend/src/routes/summary/+page.svelte
@@ -338,22 +338,3 @@
 	/>
 {/if}
 
-<!-- Submission overlay -->
-{#if isSubmitting}
-	{@const progress = workflow.state.submissionProgress}
-	<div class="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
-		<div class="flex flex-col items-center gap-6">
-			<!-- Spinning loader -->
-			<div class="w-16 h-16 rounded-full border-4 border-primary/30 border-t-primary animate-spin"></div>
-
-			<!-- Message -->
-			<p class="text-lg font-medium text-text text-center">
-				{#if progress}
-					Creating item {progress.current + 1} of {progress.total}...
-				{:else}
-					Submitting items...
-				{/if}
-			</p>
-		</div>
-	</div>
-{/if}


### PR DESCRIPTION
Remove the full-screen spinning overlay during submission on the summary page.

This improves the user experience by not blocking the entire screen, while still providing feedback through button loading states and individual item status indicators.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0ef9dc0-faa1-4ad9-8bad-ace5919c3ce1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b0ef9dc0-faa1-4ad9-8bad-ace5919c3ce1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

