### PR TITLE
Fix scroll jump on complete

### DIFF
--- a/frontend/src/routes/capture/+page.svelte
+++ b/frontend/src/routes/capture/+page.svelte
@@ -34,6 +34,10 @@
 	let progress = $derived(workflow.state.analysisProgress);
 	let locationName = $derived(workflow.state.locationName);
 
+	// True while analyzing OR while the completion animation is playing
+	// This prevents UI elements from appearing/disappearing during animation
+	let showAnalyzingUI = $derived(isAnalyzing || (status === 'reviewing' && !analysisAnimationComplete));
+
 	// Apply route guard: requires auth, location, and not in reviewing state
 	onMount(() => {
 		if (!routeGuards.capture()) return;
@@ -409,7 +413,7 @@
 			{/each}
 
 			<!-- Capture buttons inside dashed border -->
-			{#if images.length < MAX_IMAGES && !isAnalyzing}
+			{#if images.length < MAX_IMAGES && !showAnalyzingUI}
 				<CaptureButtons 
 					onCamera={() => cameraInput.click()} 
 					onUpload={() => fileInput.click()} 
@@ -419,7 +423,7 @@
 
 		<div class="flex items-center justify-between mb-6 text-sm">
 			<span class="text-text-muted">{images.length} item{images.length !== 1 ? 's' : ''} selected</span>
-			{#if !isAnalyzing}
+			{#if !showAnalyzingUI}
 				<button
 					type="button"
 					class="text-danger hover:underline"
@@ -458,7 +462,7 @@
 	/>
 
 	<!-- Analysis progress -->
-	{#if progress && (isAnalyzing || (status === 'reviewing' && !analysisAnimationComplete))}
+	{#if progress && showAnalyzingUI}
 		<AnalysisProgressBar
 			current={progress.current}
 			total={progress.total}
@@ -467,7 +471,7 @@
 		/>
 	{/if}
 
-	{#if !isAnalyzing}
+	{#if !showAnalyzingUI}
 		<Button
 			variant="primary"
 			full


### PR DESCRIPTION
Prevent jarring UI shifts on analysis completion by delaying the appearance of certain elements until the progress bar animation finishes.

Previously, UI elements like `CaptureButtons` would appear above the progress bar immediately after analysis completed (`isAnalyzing` became false), causing a layout shift. This fix introduces a `showAnalyzingUI` derived state that remains true during both active analysis and the progress bar's completion animation, ensuring a smoother transition.

---
<a href="https://cursor.com/background-agent?bcId=bc-b70f07d4-c845-49d8-83b2-247be6d5b616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b70f07d4-c845-49d8-83b2-247be6d5b616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

