### PR TITLE
Fix missing cancel button

### DIFF
--- a/frontend/src/routes/capture/+page.svelte
+++ b/frontend/src/routes/capture/+page.svelte
@@ -452,6 +452,21 @@
 			message={status === 'reviewing' ? 'Analysis complete!' : (progress.message || 'Analyzing...')}
 			onComplete={handleAnalysisComplete}
 		/>
+
+		<!-- Cancel button during analysis -->
+		{#if isAnalyzing}
+			<Button
+				variant="secondary"
+				full
+				onclick={cancelAnalysis}
+			>
+				<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<line x1="18" y1="6" x2="6" y2="18" />
+					<line x1="6" y1="6" x2="18" y2="18" />
+				</svg>
+				<span>Cancel</span>
+			</Button>
+		{/if}
 	{/if}
 
 	{#if !showAnalyzingUI}


### PR DESCRIPTION
Add a Cancel button to the capture page during LLM analysis.

The capture page had a `cancelAnalysis()` function defined but no button to trigger it. When analysis was running, the "Analyze with AI" button was hidden, but no Cancel button was shown in its place, preventing users from stopping an ongoing analysis.

---
<a href="https://cursor.com/background-agent?bcId=bc-c91ace0d-9795-4d8d-90f1-9c131c8b12d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c91ace0d-9795-4d8d-90f1-9c131c8b12d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

