### PR TITLE
Auth store subscription cleanup

### DIFF
--- a/frontend/src/lib/stores/auth.ts
+++ b/frontend/src/lib/stores/auth.ts
@@ -9,14 +9,26 @@ const storedToken = browser ? sessionStorage.getItem('hbc_token') : null;
 
 export const token = writable<string | null>(storedToken);
 
-// Persist token to sessionStorage
+// Persist token to sessionStorage with proper HMR cleanup
+let tokenUnsubscribe: (() => void) | undefined;
+
 if (browser) {
-	token.subscribe((value) => {
+	// Clean up any existing subscription (handles HMR)
+	tokenUnsubscribe?.();
+
+	tokenUnsubscribe = token.subscribe((value) => {
 		if (value) {
 			sessionStorage.setItem('hbc_token', value);
 		} else {
 			sessionStorage.removeItem('hbc_token');
 		}
+	});
+}
+
+// Clean up subscription during Vite HMR
+if (import.meta.hot) {
+	import.meta.hot.dispose(() => {
+		tokenUnsubscribe?.();
 	});
 }
 


### PR DESCRIPTION
Fix auth store token subscription to prevent multiple active subscriptions during Vite/Svelte HMR.

The previous implementation subscribed to the token at module import time without cleaning up the subscription, leading to a stack of active subscriptions writing to `sessionStorage` during HMR. This PR ensures proper cleanup via a dispose handler.

---
<a href="https://cursor.com/background-agent?bcId=bc-14b04d3a-b499-4406-9959-82d5a39178d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-14b04d3a-b499-4406-9959-82d5a39178d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

