### PR TITLE
Item creation response handling

### DIFF
--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -144,6 +144,8 @@ export interface ScanState {
 	itemStatuses: Record<number, ItemSubmissionStatus>;
 	/** Result of last successful submission (preserved for success page) */
 	lastSubmissionResult: SubmissionResult | null;
+	/** Error messages from the last submission attempt (for displaying specific failure reasons) */
+	submissionErrors: string[];
 	// Error handling
 	error: string | null;
 }
@@ -237,10 +239,39 @@ export interface CorrectionResponse {
 	message: string;
 }
 
+/** Item successfully created in Homebox (returned from backend) */
+export interface CreatedItem {
+	id: string;
+	name: string;
+	quantity: number;
+	description?: string | null;
+	/** Location object with id and name */
+	location?: {
+		id: string;
+		name?: string;
+	} | null;
+	/** Labels array with id and name */
+	labels?: Array<{
+		id: string;
+		name?: string;
+	}>;
+	// Extended fields (may be present after update)
+	manufacturer?: string | null;
+	modelNumber?: string | null;
+	serialNumber?: string | null;
+	purchasePrice?: number | null;
+	purchaseFrom?: string | null;
+	notes?: string | null;
+	insured?: boolean;
+}
+
 /** Response from batch item creation */
 export interface BatchCreateResponse {
-	created: unknown[];
+	/** Successfully created items */
+	created: CreatedItem[];
+	/** Error messages for items that failed to create */
 	errors: string[];
+	/** Summary message (e.g., "Created 2 items, 1 failed") */
 	message: string;
 }
 

--- a/frontend/src/lib/workflows/scan.svelte.ts
+++ b/frontend/src/lib/workflows/scan.svelte.ts
@@ -88,6 +88,7 @@ class ScanWorkflow {
 		'submissionProgress',
 		'itemStatuses',
 		'lastSubmissionResult',
+		'submissionErrors',
 		'error'
 	]);
 
@@ -156,6 +157,8 @@ class ScanWorkflow {
 							return workflow.submissionService.itemStatuses;
 						case 'lastSubmissionResult':
 							return workflow.submissionService.lastResult;
+						case 'submissionErrors':
+							return workflow.submissionService.lastErrors;
 						case 'error':
 							return workflow._error;
 						default:

--- a/frontend/src/routes/summary/+page.svelte
+++ b/frontend/src/routes/summary/+page.svelte
@@ -22,6 +22,7 @@
 	const locationPath = $derived(workflow.state.locationPath);
 	const locationId = $derived(workflow.state.locationId);
 	const itemStatuses = $derived(workflow.state.itemStatuses);
+	const submissionErrors = $derived(workflow.state.submissionErrors);
 
 	// Local UI state
 	let isSubmitting = $state(false);
@@ -312,6 +313,32 @@
 			</li>
 		</ul>
 	</div>
+
+	<!-- Error details (shown when there are submission errors) -->
+	{#if submissionErrors.length > 0}
+		<div class="bg-error-500/10 border border-error-500/30 rounded-xl p-4 mb-6">
+			<div class="flex items-start gap-3">
+				<svg class="w-5 h-5 text-error-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+					<circle cx="12" cy="12" r="10" />
+					<line x1="12" y1="8" x2="12" y2="12" />
+					<line x1="12" y1="16" x2="12.01" y2="16" />
+				</svg>
+				<div class="flex-1 min-w-0">
+					<h4 class="text-body-sm font-semibold text-error-300 mb-2">
+						{submissionErrors.length === 1 ? 'Error' : `${submissionErrors.length} Errors`} occurred during submission
+					</h4>
+					<ul class="space-y-1.5 text-body-sm text-error-200/80">
+						{#each submissionErrors as error}
+							<li class="flex items-start gap-2">
+								<span class="text-error-400 flex-shrink-0">•</span>
+								<span class="break-words">{error}</span>
+							</li>
+						{/each}
+					</ul>
+				</div>
+			</div>
+		</div>
+	{/if}
 
 	<!-- Actions -->
 	<div class="space-y-3">


### PR DESCRIPTION
Enhance item creation type safety and surface backend partial failures and errors to the UI.

Previously, `BatchCreateResponse` used `unknown[]`, hiding potential integration mismatches. The frontend also silently ignored `207 Multi-Status` responses with errors, leading to misleading 'success' messages. This PR introduces a concrete `CreatedItem` type and ensures all backend errors are displayed to the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac5b8255-a379-45c3-bd98-f796ddcc64a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ac5b8255-a379-45c3-bd98-f796ddcc64a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

