### PR TITLE
fix: bump version to 3.0.1 so the released image self-reports correctly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "homebox-companion"
-version = "3.0.0"
+version = "3.0.1"
 description = "AI-powered companion app for Homebox - detect and catalog household items from photos"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/uv.lock
+++ b/uv.lock
@@ -345,7 +345,7 @@ wheels = [
 
 [[package]]
 name = "homebox-companion"
-version = "2.6.1"
+version = "3.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What

Follow-up to #138. The `3.0.1`/`latest` image self-reports its version as `3.0.0`, so `/api/version` returns `update_available: true` and the in-app upgrade banner never clears:

```json
{"version":"3.0.0","latest_version":"3.0.1","update_available":true}
```

## Why

The runtime version is resolved from the installed package metadata (`server/app.py`):

```python
__version__ = version("homebox-companion")  # importlib.metadata
```

setuptools derives that from `version` in `pyproject.toml` at build time, and `docker-publish.yml` builds from the release tag's commit (`ref: ${{ github.event.release.tag_name }}`). The `v3.0.1` tag was cut from a commit where `pyproject.toml` still reads `version = "3.0.0"`, so the image reports `3.0.0` while `releases/latest` returns `v3.0.1` — the same root cause as #138, one release later. (`uv.lock`'s editable entry was also still stale at `2.6.1`, though that does not affect the reported version.)

## Fix

- `pyproject.toml`: `version` `3.0.0` → `3.0.1`
- `uv lock` to regenerate `uv.lock` (editable entry `2.6.1` → `3.0.1`)

Two-line change, no application code. A release re-tagged/rebuilt from this commit will self-report `3.0.1`.

## Verification

Ran the server from this branch:

```json
{"version":"3.0.1","latest_version":"3.0.1","update_available":false}
```

## Optional follow-up (not in this PR)

To stop the version drifting from the tag again, a release-time CI check asserting `pyproject.toml`'s version matches the pushed tag (or deriving the version from the tag) would prevent recurrence. Happy to send that separately if useful.

Refs #138
